### PR TITLE
Add a new option for the library to be able to logs with a default reporter

### DIFF
--- a/bin/vif.ml
+++ b/bin/vif.ml
@@ -1,34 +1,7 @@
 let () = Logs_threaded.enable ()
-
-let _reporter ppf =
-  let report src level ~over k msgf =
-    let k _ = over (); k () in
-    let with_metadata header _tags k ppf fmt =
-      Format.kfprintf k ppf
-        ("%a[%a]: " ^^ fmt ^^ "\n%!")
-        Logs_fmt.pp_header (level, header)
-        Fmt.(styled `Magenta string)
-        (Logs.Src.name src)
-    in
-    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt
-  in
-  { Logs.report }
-
 let error_msgf fmt = Format.kasprintf (fun msg -> Error (`Msg msg)) fmt
 
-(*
-let daemonize () =
-  let fork () = match Unix.handle_unix_error Unix.fork with
-    | 0 -> exit 0
-    | _ -> () in
-  fork ();
-  ignore (Unix.setsid ());
-  fork ();
-  Unix.chdir pwd;
-  redirect_stdio_fds
-*)
-
-let run _quiet () roots stdlib main =
+let run () roots stdlib main =
   let roots = List.map Fpath.to_string roots in
   let cfg = Vif_top.config ~stdlib roots in
   let lines =
@@ -91,87 +64,9 @@ let setup_stdlib =
   let open Term in
   ret (const setup_stdlib $ const ())
 
-let docs_output = "OUTPUT"
-
-let verbosity =
-  let env = Cmd.Env.info "VIF_LOGS" in
-  Logs_cli.level ~env ~docs:docs_output ()
-
-let renderer =
-  let env = Cmd.Env.info "VIF_FMT" in
-  Fmt_cli.style_renderer ~env ~docs:docs_output ()
-
-let utf_8 =
-  let doc = "Allow us to emit UTF-8 characters." in
-  let env = Cmd.Env.info "VIF_UTF_8" in
-  let open Arg in
-  value
-  & opt bool true
-  & info [ "with-utf-8" ] ~doc ~docv:"BOOL" ~docs:docs_output ~env
-
-let app_style = `Cyan
-let err_style = `Red
-let warn_style = `Yellow
-let info_style = `Blue
-let debug_style = `Green
-
-let pp_header ~pp_h ppf (l, h) =
-  match l with
-  | Logs.Error ->
-      let h = Option.value ~default:"ERROR" h in
-      pp_h ppf err_style h
-  | Logs.Warning ->
-      let h = Option.value ~default:"WARN" h in
-      pp_h ppf warn_style h
-  | Logs.Info ->
-      let h = Option.value ~default:"INFO" h in
-      pp_h ppf info_style h
-  | Logs.Debug ->
-      let h = Option.value ~default:"DEBUG" h in
-      pp_h ppf debug_style h
-  | Logs.App ->
-      Fun.flip Option.iter h @@ fun h ->
-      Fmt.pf ppf "[%a] " Fmt.(styled app_style (fmt "%10s")) h
-
-let pp_header =
-  let pp_h ppf style h = Fmt.pf ppf "[%a]" Fmt.(styled style (fmt "%10s")) h in
-  pp_header ~pp_h
-
-let reporter ppf =
-  let report src level ~over k msgf =
-    let k _ = over (); k () in
-    let with_metadata header _tags k ppf fmt =
-      Fmt.kpf k ppf
-        ("[%02d]%a[%a]: @[<hov>" ^^ fmt ^^ "@]\n%!")
-        (Stdlib.Domain.self () :> int)
-        pp_header (level, header)
-        Fmt.(styled `Magenta (fmt "%20s"))
-        (Logs.Src.name src)
-    in
-    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt
-  in
-  { Logs.report }
-
-let setup_logs utf_8 style_renderer level =
-  let stdout =
-    Format.make_formatter (output_substring stdout) (fun () -> flush stdout)
-  in
-  Fmt_tty.setup_std_outputs ~utf_8 ?style_renderer ();
-  let reporter = reporter Fmt.stderr in
-  Logs.set_reporter reporter;
-  Logs.set_level level;
-  (Option.is_none level, stdout)
-
-let setup_logs = Term.(const setup_logs $ utf_8 $ renderer $ verbosity)
-
 let term =
   let open Term in
-  const run
-  $ setup_logs
-  $ Vif.setup_config
-  $ Vif_mmeta.setup
-  $ setup_stdlib
-  $ main
+  const run $ Vif.setup_config $ Vif_mmeta.setup $ setup_stdlib $ main
 
 let cmd =
   let doc = "vif" in

--- a/lib/vif/dune
+++ b/lib/vif/dune
@@ -37,6 +37,9 @@
   decompress.gz
   tyxml
   httpcats.core
+  logs.fmt
+  fmt.cli
+  logs.cli
   tyre))
 
 (library

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -368,6 +368,8 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
     ?(middlewares = Middlewares.[]) ?(handlers = []) ?websocket routes
     user's_value =
   let rng = Mirage_crypto_rng_miou_unix.(initialize (module Pfortuna)) in
+  Option.iter Logs.set_reporter cfg.reporter;
+  Option.iter Logs.set_level cfg.level;
   let finally () = Mirage_crypto_rng_miou_unix.kill rng in
   Fun.protect ~finally @@ fun () ->
   let interactive = !Sys.interactive in

--- a/lib/vif/vif.mli
+++ b/lib/vif/vif.mli
@@ -1097,6 +1097,8 @@ val config :
      ?domains:int
   -> ?cookie_key:Mirage_crypto.AES.GCM.key
   -> ?pid:Fpath.t
+  -> ?reporter:Logs.reporter
+  -> ?level:Logs.level option
   -> ?http:
        [ `H1 of H1.Config.t
        | `H2 of H2.Config.t

--- a/lib/vif/vif_config_unix.ml
+++ b/lib/vif/vif_config_unix.ml
@@ -10,6 +10,8 @@ type config = {
   ; pid: Fpath.t option
   ; cookie_key: Mirage_crypto.AES.GCM.key
   ; domains: int
+  ; reporter: Logs.reporter option
+  ; level: Logs.level option option
 }
 
 let really_bad_secret =
@@ -21,7 +23,7 @@ let really_bad_secret =
 let default_domains = Int.min (Stdlib.Domain.recommended_domain_count ()) 4
 
 let config ?(domains = default_domains) ?(cookie_key = really_bad_secret) ?pid
-    ?http ?tls ?(backlog = 64) sockaddr =
+    ?reporter ?level ?http ?tls ?(backlog = 64) sockaddr =
   let http =
     match http with
     | Some (`H1 cfg) -> Some (`HTTP_1_1 cfg)
@@ -29,4 +31,4 @@ let config ?(domains = default_domains) ?(cookie_key = really_bad_secret) ?pid
     | Some (`Both (h1, h2)) -> Some (`Both (h1, h2))
     | None -> None
   in
-  { http; tls; backlog; sockaddr; pid; cookie_key; domains }
+  { http; tls; backlog; sockaddr; pid; cookie_key; domains; reporter; level }

--- a/lib/vif/vif_options_unix.ml
+++ b/lib/vif/vif_options_unix.ml
@@ -4,17 +4,22 @@ let inet_addr = ref Unix.inet_addr_loopback
 let backlog = ref 64
 let pid = ref None
 let domains = ref None
+let reporter = ref None
+let level = ref None
 
-let setup_config domains' port' inet_addr' backlog' pid' =
+let setup_config domains' port' inet_addr' backlog' pid' reporter' level' =
   port := port';
   inet_addr := inet_addr';
   backlog := backlog';
   pid := pid';
-  domains := domains'
+  domains := domains';
+  reporter := reporter';
+  level := Some level'
 
 let config_from_globals () =
   let sockaddr = Unix.(ADDR_INET (!inet_addr, !port)) in
-  Vif_config_unix.config ?domains:!domains ?pid:!pid ~backlog:!backlog sockaddr
+  Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
+    ?pid:!pid ~backlog:!backlog sockaddr
 
 open Cmdliner
 
@@ -68,6 +73,97 @@ let backlog =
   let open Arg in
   value & opt int 64 & info [ "backlog" ] ~doc ~docv:"NUMBER"
 
+let docs_output = "OUTPUT"
+let t0 = Unix.gettimeofday ()
+
+let reporter sources ppf =
+  let re = Option.map Re.compile sources in
+  let print src =
+    let neg = Fun.negate in
+    let some re = (neg List.is_empty) (Re.matches re (Logs.Src.name src)) in
+    Option.fold ~none:true ~some re
+  in
+  let report src level ~over k msgf =
+    let k _ = over (); k () in
+    let pp header _tags k ppf fmt =
+      let t1 = Unix.gettimeofday () in
+      let delta = t1 -. t0 in
+      let delta = delta /. 1_000_000_000. in
+      Fmt.kpf k ppf
+        ("[+%a][%a]%a[%a]: " ^^ fmt ^^ "\n%!")
+        Fmt.(styled `Blue (fmt "%04.04f"))
+        delta
+        Fmt.(styled `Cyan int)
+        (Stdlib.Domain.self () :> int)
+        Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src)
+    in
+    match (level, print src) with
+    | Logs.Debug, false -> k ()
+    | _, true | _ -> msgf @@ fun ?header ?tags fmt -> pp header tags k ppf fmt
+  in
+  { Logs.report }
+
+let setup_sources = function
+  | [ (_, `None) ] -> None
+  | res ->
+      let res = List.map snd res in
+      let res =
+        List.fold_left
+          (fun acc -> function `Re re -> re :: acc | _ -> acc)
+          [] res
+      in
+      Some (Re.alt res)
+
+let setup_reporter sources utf_8 style_renderer =
+  Option.iter (Fmt.set_style_renderer Fmt.stdout) style_renderer;
+  Fmt.set_utf_8 Fmt.stdout utf_8;
+  Some (reporter sources Fmt.stdout)
+
+let renderer =
+  let env = Cmd.Env.info "VIF_FMT" in
+  Fmt_cli.style_renderer ~env ~docs:docs_output ()
+
+let regexp : (string * [ `None | `Re of Re.t ]) Arg.conv =
+  let parser str =
+    match Re.Pcre.re str with
+    | re -> Ok (str, `Re re)
+    | exception _ -> error_msgf "Invalid PCRegexp: %S" str
+  in
+  let pp ppf (str, _) = Fmt.string ppf str in
+  Arg.conv (parser, pp)
+
+let sources =
+  let doc = "A regexp (PCRE syntax) to identify which log we print." in
+  let open Arg in
+  value & opt_all regexp [ ("", `None) ] & info [ "l" ] ~doc ~docv:"REGEXP"
+
+let setup_sources = Term.(const setup_sources $ sources)
+
+let utf_8 =
+  let doc = "Allow us to emit UTF-8 characters." in
+  let env = Cmd.Env.info "VIF_UTF_8" in
+  let open Arg in
+  value
+  & opt bool true
+  & info [ "with-utf-8" ] ~doc ~docv:"BOOL" ~docs:docs_output ~env
+
+let setup_reporter =
+  let open Term in
+  const setup_reporter $ setup_sources $ utf_8 $ renderer
+
+let verbosity =
+  let env = Cmd.Env.info "VIF_LOGS" in
+  Logs_cli.level ~env ~docs:docs_output ()
+
 let setup_config =
   let open Term in
-  const setup_config $ domains $ port $ inet_addr $ backlog $ pid
+  const setup_config
+  $ domains
+  $ port
+  $ inet_addr
+  $ backlog
+  $ pid
+  $ setup_reporter
+  $ verbosity


### PR DESCRIPTION
This PR add new options on the configuration of the server to be able to print out logs. By default, the reporter prints on `stderr` and the user can set the level of logs. By this way, we can have a nice output with `Vif.run` and debug when it does not work (/cc @clecat & @voodoos who asked me to do this).