### PR TITLE
Allow `Vif.run` caller to provide their own `stop`

### DIFF
--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -402,15 +402,17 @@ let default_from_handlers handlers req target server user's_value =
   | None -> default req target server user's_value
 
 let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
-    ?(middlewares = Middlewares.[]) ?(handlers = []) ?websocket routes
+    ?(middlewares = Middlewares.[]) ?(handlers = []) ?websocket ?stop routes
     user's_value =
   Option.iter Logs.set_reporter cfg.reporter;
   Option.iter Logs.set_level cfg.level;
   let interactive = !Sys.interactive in
   let domains = Int.min (Miou.Domain.available ()) cfg.domains in
   let stop =
-    match interactive with
-    | true ->
+    match (interactive, stop) with
+    | _, Some _ -> stop (* if the caller provided a stop, always use it *)
+    | true, None ->
+        (* if we're interactive with no stop, stop on SIGINT *)
         let stop = Httpcats.Server.stop () in
         let fn _sigint =
           Log.debug (fun m -> m "Server shutdown request (SIGINT)");
@@ -419,7 +421,7 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
         let behavior = Sys.Signal_handle fn in
         ignore (Miou.sys_signal Sys.sigint behavior);
         Some stop
-    | false -> None
+    | false, None -> None (* otherwise there's nothing to be done *)
   in
   Logs.debug (fun m -> m "Vif.run, interactive:%b" interactive);
   let devices =

--- a/lib/vif/vif.mli
+++ b/lib/vif/vif.mli
@@ -1129,6 +1129,7 @@ val run :
   -> ?middlewares:'value Middlewares.t
   -> ?handlers:('c, 'value) Handler.t list
   -> ?websocket:(ic -> oc -> Server.t -> 'value -> unit)
+  -> ?stop:Httpcats.Server.stop
   -> (Server.t -> 'value -> (Response.empty, Response.sent, unit) Response.t)
      Route.t
      list

--- a/lib/vif/vif_response.ml
+++ b/lib/vif/vif_response.ml
@@ -143,8 +143,8 @@ let with_tyxml ?compression:alg req tyxml =
   let* _ = add_unless_exists ~field v in
   let* _ = connection_close req in
   let source =
-    Flux.Source.with_buffered_formatter ~size:0x7ff ~buffer_size:0x7ff @@ fun ppf ->
-    Fmt.pf ppf "%a" (Tyxml.Html.pp ()) tyxml
+    Flux.Source.with_buffered_formatter ~size:0x7ff ~buffer_size:0x7ff
+    @@ fun ppf -> Fmt.pf ppf "%a" (Tyxml.Html.pp ()) tyxml
   in
   Source source
 


### PR DESCRIPTION
The plain Vif API only creates a stop for `httpcats` when the process is interactive. We want to pass our own stop in. This permits that, and runs `ocamlformat` on the files we touched.