### PR TITLE
switch to listen specifiers, adding `-U` option and unix-socket support

### DIFF
--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -434,8 +434,12 @@ let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
         Some stop
     | false, None -> None (* otherwise there's nothing to be done *)
   in
-  let listen = match cfg.sockaddr with
-    | Unix.ADDR_UNIX _ as unix -> bind_unix_socket cfg.backlog unix
+  let listen =
+    match cfg.sockaddr with
+    | Unix.ADDR_UNIX path as unix ->
+        let delete () = try Unix.unlink path with _exn -> () in
+        let ret = bind_unix_socket cfg.backlog unix in
+        at_exit delete; ret
     | _ as inet -> Httpcats.Server.Bind inet
   in
   Logs.debug (fun m -> m "Vif.run, interactive:%b" interactive);

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -404,7 +404,7 @@ let bind_unix_socket backlog unix =
   let fd = Miou_unix.unix_socket () in
   Log.debug (fun m -> m "Binding UNIX socket early to pass it as fd");
   Miou_unix.bind_and_listen ~backlog fd unix;
-  Httpcats.Server.Use (fd, unix)
+  fd
 
 let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
     ?(handlers = []) ?websocket ?stop routes user's_value =
@@ -430,13 +430,14 @@ let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
         Some stop
     | false, None -> None (* otherwise there's nothing to be done *)
   in
-  let listen =
+  let closer, listen =
     match cfg.sockaddr with
     | Unix.ADDR_UNIX path as unix ->
         let delete () = try Unix.unlink path with _exn -> () in
-        let ret = bind_unix_socket cfg.backlog unix in
-        at_exit delete; ret
-    | _ as inet -> Httpcats.Server.Bind inet
+        let fd = bind_unix_socket cfg.backlog unix in
+        at_exit delete;
+        (Some fd, Httpcats.Server.Use (fd, unix))
+    | _ as inet -> (None, Httpcats.Server.Bind inet)
   in
   Logs.debug (fun m -> m "Vif.run, interactive:%b" interactive);
   let devices =
@@ -491,6 +492,7 @@ let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
   Miou.await_exn prm0;
   Miou.await_exn prm1;
   List.iter (function Ok () -> () | Error exn -> raise exn) prmn;
+  Option.iter Miou_unix.close closer;
   Devices.finally (Vif_core.Device.Devices devices);
   Log.debug (fun m -> m "Vif (and devices) terminated")
 

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -413,7 +413,7 @@ let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
     | None -> Vif_options_unix.config_from_globals ()
     | Some c -> Ok c
   in
-  let open Result.Syntax in
+  let ( let* ) = Result.bind in
   let* cfg in
   Option.iter Logs.set_reporter cfg.reporter;
   Option.iter Logs.set_level cfg.level;

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -408,13 +408,9 @@ let bind_unix_socket backlog unix =
 
 let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
     ?(handlers = []) ?websocket ?stop routes user's_value =
-  let cfg =
-    match cfg with
-    | None -> Vif_options_unix.config_from_globals ()
-    | Some c -> Ok c
-  in
-  let ( let* ) = Result.bind in
-  let* cfg in
+  let cfg = match cfg with
+    | Some cfg -> cfg
+    | None -> Vif_options_unix.config_from_globals () in
   Option.iter Logs.set_reporter cfg.reporter;
   Option.iter Logs.set_level cfg.level;
   let interactive = !Sys.interactive in
@@ -496,8 +492,7 @@ let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
   Miou.await_exn prm1;
   List.iter (function Ok () -> () | Error exn -> raise exn) prmn;
   Devices.finally (Vif_core.Device.Devices devices);
-  Log.debug (fun m -> m "Vif (and devices) terminated");
-  Ok ()
+  Log.debug (fun m -> m "Vif (and devices) terminated")
 
 let setup_config = Vif_options_unix.setup_config
 let reporter ~sources ~ppf = Vif_options_unix.reporter sources ppf

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -408,9 +408,11 @@ let bind_unix_socket backlog unix =
 
 let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
     ?(handlers = []) ?websocket ?stop routes user's_value =
-  let cfg = match cfg with
+  let cfg =
+    match cfg with
     | Some cfg -> cfg
-    | None -> Vif_options_unix.config_from_globals () in
+    | None -> Vif_options_unix.config_from_globals ()
+  in
   Option.iter Logs.set_reporter cfg.reporter;
   Option.iter Logs.set_level cfg.level;
   let interactive = !Sys.interactive in

--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -317,7 +317,7 @@ type config = Vif_config_unix.config
 let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore
 let config = Vif_config_unix.config
 
-let process stop cfg server user's_value ready (fn, ws_fn) =
+let process stop cfg server user's_value ready listen (fn, ws_fn) =
   Logs.debug (fun m ->
       m "new HTTP server on [%d]" (Stdlib.Domain.self () :> int));
   let daemon =
@@ -341,7 +341,7 @@ let process stop cfg server user's_value ready (fn, ws_fn) =
   | config, Some tls ->
       let upgrade flow = ws_handler daemon ws_fn (`Tls flow) in
       Httpcats.Server.with_tls ~parallel ~upgrade ?stop ?config
-        ~backlog:cfg.backlog tls ~ready ~handler:fn cfg.sockaddr;
+        ~backlog:cfg.backlog tls ~ready ~handler:fn listen;
       Miou.cancel user's_tasks
   | Some (`H2 _), None ->
       Miou.cancel user's_tasks;
@@ -350,13 +350,12 @@ let process stop cfg server user's_value ready (fn, ws_fn) =
   | Some (`Both (config, _) | `HTTP_1_1 config), None ->
       let upgrade flow = ws_handler daemon ws_fn (`Tcp flow) in
       Httpcats.Server.clear ~parallel ~upgrade ?stop ~config ~ready ~handler:fn
-        cfg.sockaddr;
+        listen;
       Miou.cancel user's_tasks
   | None, None ->
       let upgrade flow = ws_handler daemon ws_fn (`Tcp flow) in
       Log.debug (fun m -> m "Start a non-tweaked HTTP/1.1 server");
-      Httpcats.Server.clear ~parallel ~upgrade ?stop ~ready ~handler:fn
-        cfg.sockaddr;
+      Httpcats.Server.clear ~parallel ~upgrade ?stop ~ready ~handler:fn listen;
       Miou.cancel user's_tasks
 
 let store_pid = function
@@ -401,9 +400,21 @@ let default_from_handlers handlers req target server user's_value =
   | Some p -> p
   | None -> default req target server user's_value
 
-let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
-    ?(middlewares = Middlewares.[]) ?(handlers = []) ?websocket ?stop routes
-    user's_value =
+let bind_unix_socket backlog unix =
+  let fd = Miou_unix.unix_socket () in
+  Log.debug (fun m -> m "Binding UNIX socket early to pass it as fd");
+  Miou_unix.bind_and_listen ~backlog fd unix;
+  Httpcats.Server.Use (fd, unix)
+
+let run ?cfg ?(devices = Devices.[]) ?(middlewares = Middlewares.[])
+    ?(handlers = []) ?websocket ?stop routes user's_value =
+  let cfg =
+    match cfg with
+    | None -> Vif_options_unix.config_from_globals ()
+    | Some c -> Ok c
+  in
+  let open Result.Syntax in
+  let* cfg in
   Option.iter Logs.set_reporter cfg.reporter;
   Option.iter Logs.set_level cfg.level;
   let interactive = !Sys.interactive in
@@ -422,6 +433,10 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
         ignore (Miou.sys_signal Sys.sigint behavior);
         Some stop
     | false, None -> None (* otherwise there's nothing to be done *)
+  in
+  let listen = match cfg.sockaddr with
+    | Unix.ADDR_UNIX _ as unix -> bind_unix_socket cfg.backlog unix
+    | _ as inet -> Httpcats.Server.Bind inet
   in
   Logs.debug (fun m -> m "Vif.run, interactive:%b" interactive);
   let devices =
@@ -450,7 +465,7 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
   let rd0 = Miou.Computation.create () in
   let prm0 =
     Miou.async @@ fun () ->
-    process stop cfg server user's_value rd0 (fn0, ws_fn0)
+    process stop cfg server user's_value rd0 listen (fn0, ws_fn0)
   in
   let tasks =
     let fn _ =
@@ -469,7 +484,7 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
   in
   let prmn =
     let fn (ready, fn, ws_fn) =
-      process stop cfg server user's_value ready (fn, ws_fn)
+      process stop cfg server user's_value ready listen (fn, ws_fn)
     in
     if domains > 0 then Miou.parallel fn tasks else []
   in
@@ -477,7 +492,8 @@ let run ?(cfg = Vif_options_unix.config_from_globals ()) ?(devices = Devices.[])
   Miou.await_exn prm1;
   List.iter (function Ok () -> () | Error exn -> raise exn) prmn;
   Devices.finally (Vif_core.Device.Devices devices);
-  Log.debug (fun m -> m "Vif (and devices) terminated")
+  Log.debug (fun m -> m "Vif (and devices) terminated");
+  Ok ()
 
 let setup_config = Vif_options_unix.setup_config
 let reporter ~sources ~ppf = Vif_options_unix.reporter sources ppf

--- a/lib/vif/vif.mli
+++ b/lib/vif/vif.mli
@@ -1134,7 +1134,7 @@ val run :
      Route.t
      list
   -> 'value
-  -> (unit, string) result
+  -> unit
 
 (**/*)
 

--- a/lib/vif/vif.mli
+++ b/lib/vif/vif.mli
@@ -1134,7 +1134,7 @@ val run :
      Route.t
      list
   -> 'value
-  -> unit
+  -> (unit, string) result
 
 (**/*)
 

--- a/lib/vif/vif_options_unix.ml
+++ b/lib/vif/vif_options_unix.ml
@@ -1,8 +1,8 @@
 let default_addr = Unix.inet_addr_loopback
 let default_port = 8080
 let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
-let port = ref default_port
-let inet_addr = ref default_addr
+let port = ref None
+let inet_addr = ref None
 let backlog = ref 64
 let pid = ref None
 let domains = ref None
@@ -22,17 +22,14 @@ let setup_config domains' port' inet_addr' backlog' pid' reporter' level'
   unix_socket := unix_socket'
 
 let config_from_globals () =
-  let inet_sockaddr = Unix.ADDR_INET (!inet_addr, !port) in
-  let is_default =
-    inet_sockaddr = Unix.ADDR_INET (default_addr, default_port)
-  in
   let ( let* ) = Result.bind in
   let* sockaddr =
-    match (is_default, !unix_socket) with
-    | true, Some path -> Ok (Unix.ADDR_UNIX path)
-    | true, None -> Ok inet_sockaddr
-    | false, None -> Ok inet_sockaddr
-    | false, Some _ -> Error "cannot mix internet and unix sockets"
+    match !inet_addr, !port, !unix_socket with
+    | _, _, None ->
+      Ok (Unix.ADDR_INET (Option.value !inet_addr ~default:default_addr,
+                          Option.value !port ~default:default_port))
+    | None, None, Some path -> Ok (Unix.ADDR_UNIX path)
+    | _ -> Error "cannot mix internet and unix sockets"
   in
   Ok
     (Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
@@ -43,7 +40,7 @@ open Cmdliner
 let port =
   let doc = "The port used by the HTTP server." in
   let open Arg in
-  value & opt int default_port & info [ "p"; "port" ] ~doc ~docv:"PORT"
+  value & opt (some int) None & info [ "p"; "port" ] ~doc ~docv:"PORT"
 
 let inet_addr =
   let doc = "The address to bind the HTTP server." in
@@ -55,7 +52,7 @@ let inet_addr =
   let inet_addr = Arg.conv (parser, pp) in
   let open Arg in
   value
-  & opt inet_addr default_addr
+  & opt (some inet_addr) None
   & info [ "i"; "inet-addr" ] ~doc ~docv:"INET_ADDR"
 
 let unix_socket =

--- a/lib/vif/vif_options_unix.ml
+++ b/lib/vif/vif_options_unix.ml
@@ -1,39 +1,22 @@
-let default_addr = Unix.inet_addr_loopback
-let default_port = 8080
 let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
-let port = ref None
-let inet_addr = ref None
+let sockaddr = ref Unix.(ADDR_INET (inet_addr_loopback, 8080))
 let backlog = ref 64
 let pid = ref None
 let domains = ref None
 let reporter = ref None
 let level = ref None
-let unix_socket = ref None
 
-let setup_config domains' port' inet_addr' backlog' pid' reporter' level'
-    unix_socket' =
-  port := port';
-  inet_addr := inet_addr';
+let setup_config domains' sockaddr' backlog' pid' reporter' level' =
+  sockaddr := sockaddr';
   backlog := backlog';
   pid := pid';
   domains := domains';
   reporter := reporter';
-  level := Some level';
-  unix_socket := unix_socket'
+  level := Some level'
 
 let config_from_globals () =
-  let ( let* ) = Result.bind in
-  let* sockaddr =
-    match !inet_addr, !port, !unix_socket with
-    | _, _, None ->
-      Ok (Unix.ADDR_INET (Option.value !inet_addr ~default:default_addr,
-                          Option.value !port ~default:default_port))
-    | None, None, Some path -> Ok (Unix.ADDR_UNIX path)
-    | _ -> Error "cannot mix internet and unix sockets"
-  in
-  Ok
-    (Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
-       ?pid:!pid ~backlog:!backlog sockaddr)
+  Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
+    ?pid:!pid ~backlog:!backlog !sockaddr
 
 open Cmdliner
 
@@ -59,6 +42,21 @@ let unix_socket =
   let doc = "The unix socket to bind the HTTP server." in
   let open Arg in
   value & opt (some string) None & info [ "U"; "unix-socket" ] ~doc ~docv:"PATH"
+
+let setup_sockaddr inet_addr port unix_socket =
+  match inet_addr, port, unix_socket with
+  | None, None, None -> Ok Unix.(ADDR_INET (inet_addr_loopback, 8080))
+  | None, Some port, None -> Ok Unix.(ADDR_INET (inet_addr_loopback, port))
+  | Some inet_addr, None, None -> Ok Unix.(ADDR_INET (inet_addr, 8080))
+  | Some inet_addr, Some port, None -> Ok Unix.(ADDR_INET (inet_addr, port))
+  | None, _, Some unix_socket -> Ok Unix.(ADDR_UNIX unix_socket)
+  | Some _, _, Some _ -> error_msgf "Impossible to initialize a server on a UNIX socket and an address at the same time"
+
+let setup_sockaddr =
+  let open Term in
+  const setup_sockaddr
+  $ inet_addr $ port $ unix_socket
+  |> term_result ~usage:true
 
 let is_not_directory str =
   (Sys.file_exists str && Sys.is_directory str = false)
@@ -180,10 +178,8 @@ let setup_config =
   let open Term in
   const setup_config
   $ domains
-  $ port
-  $ inet_addr
+  $ setup_sockaddr
   $ backlog
   $ pid
   $ setup_reporter
   $ verbosity
-  $ unix_socket

--- a/lib/vif/vif_options_unix.ml
+++ b/lib/vif/vif_options_unix.ml
@@ -26,7 +26,7 @@ let config_from_globals () =
   let is_default =
     inet_sockaddr = Unix.ADDR_INET (default_addr, default_port)
   in
-  let open Result.Syntax in
+  let ( let* ) = Result.bind in
   let* sockaddr =
     match (is_default, !unix_socket) with
     | true, Some path -> Ok (Unix.ADDR_UNIX path)

--- a/lib/vif/vif_options_unix.ml
+++ b/lib/vif/vif_options_unix.ml
@@ -1,32 +1,49 @@
+let default_addr = Unix.inet_addr_loopback
+let default_port = 8080
 let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
-let port = ref 8080
-let inet_addr = ref Unix.inet_addr_loopback
+let port = ref default_port
+let inet_addr = ref default_addr
 let backlog = ref 64
 let pid = ref None
 let domains = ref None
 let reporter = ref None
 let level = ref None
+let unix_socket = ref None
 
-let setup_config domains' port' inet_addr' backlog' pid' reporter' level' =
+let setup_config domains' port' inet_addr' backlog' pid' reporter' level'
+    unix_socket' =
   port := port';
   inet_addr := inet_addr';
   backlog := backlog';
   pid := pid';
   domains := domains';
   reporter := reporter';
-  level := Some level'
+  level := Some level';
+  unix_socket := unix_socket'
 
 let config_from_globals () =
-  let sockaddr = Unix.(ADDR_INET (!inet_addr, !port)) in
-  Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
-    ?pid:!pid ~backlog:!backlog sockaddr
+  let inet_sockaddr = Unix.ADDR_INET (!inet_addr, !port) in
+  let is_default =
+    inet_sockaddr = Unix.ADDR_INET (default_addr, default_port)
+  in
+  let open Result.Syntax in
+  let* sockaddr =
+    match (is_default, !unix_socket) with
+    | true, Some path -> Ok (Unix.ADDR_UNIX path)
+    | true, None -> Ok inet_sockaddr
+    | false, None -> Ok inet_sockaddr
+    | false, Some _ -> Error "cannot mix internet and unix sockets"
+  in
+  Ok
+    (Vif_config_unix.config ?reporter:!reporter ?level:!level ?domains:!domains
+       ?pid:!pid ~backlog:!backlog sockaddr)
 
 open Cmdliner
 
 let port =
   let doc = "The port used by the HTTP server." in
   let open Arg in
-  value & opt int 8080 & info [ "p"; "port" ] ~doc ~docv:"PORT"
+  value & opt int default_port & info [ "p"; "port" ] ~doc ~docv:"PORT"
 
 let inet_addr =
   let doc = "The address to bind the HTTP server." in
@@ -38,8 +55,13 @@ let inet_addr =
   let inet_addr = Arg.conv (parser, pp) in
   let open Arg in
   value
-  & opt inet_addr Unix.inet_addr_loopback
+  & opt inet_addr default_addr
   & info [ "i"; "inet-addr" ] ~doc ~docv:"INET_ADDR"
+
+let unix_socket =
+  let doc = "The unix socket to bind the HTTP server." in
+  let open Arg in
+  value & opt (some string) None & info [ "U"; "unix-socket" ] ~doc ~docv:"PATH"
 
 let is_not_directory str =
   (Sys.file_exists str && Sys.is_directory str = false)
@@ -62,7 +84,7 @@ let pid =
   & info [ "pid-file" ] ~doc ~docv:"PATH"
 
 let domains =
-  let doc = "The number of number used by vif." in
+  let doc = "The number of domains used by vif." in
   let open Arg in
   value & opt (some int) None & info [ "domains" ] ~doc ~docv:"DOMAINS"
 
@@ -167,3 +189,4 @@ let setup_config =
   $ pid
   $ setup_reporter
   $ verbosity
+  $ unix_socket

--- a/lib/vif/vif_options_unix.mli
+++ b/lib/vif/vif_options_unix.mli
@@ -1,3 +1,3 @@
 val reporter : Re.t option -> Format.formatter -> Logs.reporter
-val config_from_globals : unit -> (Vif_config_unix.config, string) result
+val config_from_globals : unit -> Vif_config_unix.config
 val setup_config : unit Cmdliner.Term.t

--- a/lib/vif/vif_options_unix.mli
+++ b/lib/vif/vif_options_unix.mli
@@ -1,0 +1,3 @@
+val reporter : Re.t option -> Format.formatter -> Logs.reporter
+val config_from_globals : unit -> (Vif_config_unix.config, string) result
+val setup_config : unit Cmdliner.Term.t

--- a/vif.opam
+++ b/vif.opam
@@ -45,3 +45,8 @@ run-test: [
 ]
 synopsis: "A simple web framework for OCaml 5"
 x-ci-accept-failures: ["debian-11"]
+pin-depends: [
+  [ "httpcats.dev" "git+https://github.com/theAlexes/httpcats.git#24da9e5e28680454ef6d4f0e4a6b8874dad21820" ]
+  [ "hurl.dev" "git+https://github.com/theAlexes/hurl.git#a40887089ccddc1f1e8d3467a53e41bfab1664c9" ]
+  [ "miou.dev" "git+https://github.com/robur-coop/miou.git#784a934eb90620f8214a264fcd617334305f8b44" ]
+]


### PR DESCRIPTION
Builds on current tip of `httpcats` et al when pinned locally.

Fixes #30.