### PR TITLE
Revert shutdown

### DIFF
--- a/lib/vif/vif.ml
+++ b/lib/vif/vif.ml
@@ -201,7 +201,7 @@ let dispatch_task daemon = function
             Vif_core.Response.(run ~now req0 Empty)
               (fn daemon.server daemon.user's_value)
           in
-          Vif_core.Request0.shutdown req0
+          Vif_core.Request0.close req0
         with exn ->
           let bt = Printexc.get_raw_backtrace () in
           Log.err (fun m ->
@@ -281,7 +281,7 @@ let handler ~default ~middlewares routes daemon =
                 (fn daemon.server daemon.user's_value)
             in
             Log.debug (fun m -> m "Response terminated, close our request");
-            Vif_core.Request0.shutdown req0
+            Vif_core.Request0.close req0
           with exn ->
             Log.err (fun m ->
                 m "Unexpected response from our handler: %s"

--- a/lib/vif/vif_request.ml
+++ b/lib/vif/vif_request.ml
@@ -27,6 +27,7 @@ let headers { request; _ } = Vif_request0.headers request
 let reqd { request; _ } = Vif_request0.reqd request
 let source { request; _ } = Vif_request0.source request
 let accept { request; _ } = Vif_request0.accept request
+let close { request; _ } = Vif_request0.close request
 let shutdown { request; _ } = Vif_request0.shutdown request
 let tags { request; _ } = Vif_request0.tags request
 

--- a/lib/vif/vif_request0.ml
+++ b/lib/vif/vif_request0.ml
@@ -137,10 +137,18 @@ let source { reqd; tags; _ } =
       m ~tags "the user request for a source of the request");
   to_source ~src reqd
 
+let close { body; tags; _ } =
+  Log.debug (fun m ->
+      let tags = Lazy.force tags in
+      m ~tags "close the request body reader");
+  match body with
+  | `V1 body -> H1.Body.Reader.close body
+  | `V2 body -> H2.Body.Reader.close body
+
 let shutdown { conn; tags; _ } =
   Log.debug (fun m ->
       let tags = Lazy.force tags in
-      m ~tags "close the reader body");
+      m ~tags "shutdown the http connection");
   match conn with
   | `H1 conn -> H1.Server_connection.shutdown conn
   | `H2 conn -> H2.Server_connection.shutdown conn

--- a/lib/vif/vifu.ml
+++ b/lib/vif/vifu.ml
@@ -185,7 +185,7 @@ let dispatch_task daemon = function
             Vif_core.Response.(run ~now req0 Empty)
               (fn daemon.server daemon.user's_value)
           in
-          Vif_core.Request0.shutdown req0
+          Vif_core.Request0.close req0
         with exn ->
           let bt = Printexc.get_raw_backtrace () in
           Log.err (fun m ->
@@ -250,7 +250,7 @@ let handler ~default ~middlewares routes daemon =
               Vif_core.Response.(run ~now req0 Empty)
                 (fn daemon.server daemon.user's_value)
             in
-            Vif_core.Request0.shutdown req0
+            Vif_core.Request0.close req0
           with exn -> Vif_core.Request0.report_exn req0 exn
           end
       | _ -> begin

--- a/vif.opam
+++ b/vif.opam
@@ -48,5 +48,5 @@ x-ci-accept-failures: ["debian-11"]
 pin-depends: [
   [ "hurl.dev" "git+https://github.com/robur-coop/hurl.git#054446c616026e927de575c3e483cd6876a10068" ]
   [ "miou.dev" "git+https://github.com/robur-coop/miou.git#4e8fd306c305142035f65a1339ca1aa9f011c955" ]
-  [ "httpcats.dev" "git+https://github.com/robur-coop/httpcats.git#6b19476a1fa95cdee34150ba8e4f5636d343b908" ]
+  [ "httpcats.dev" "git+https://github.com/robur-coop/httpcats.git#3e6cd0d5ae9bfebce9476965778c491b3bb7b415" ]
 ]


### PR DESCRIPTION
/cc @voodoos /cc @theAlexes. I think this PR is the final one which fix a regression spotted by @voodoos (when I merged [!60](https://git.robur.coop/robur/vif/pulls/60) to fix #32) and the initial bug spotted by @theAlexes. Can you both confirm that you are happy with the current state of `vif` and `httpcats`?